### PR TITLE
fix: strip tabs and trailing whitespace from generated RST output

### DIFF
--- a/convert.php
+++ b/convert.php
@@ -221,8 +221,10 @@ foreach ($blocks as $block) {
 		$code = trim($code);
 		// indent every line by 4 spaces - also trim whitespace
 		// (for example: empty lines at the end)
+		// expand tabs to spaces and skip indent on empty lines to avoid trailing whitespace
 		foreach (explode("\n", trim($code)) as $line) {
-			$RSTRepresentation .= "    " . $line . "\n";
+			$line = rtrim(str_replace("\t", "    ", $line));
+			$RSTRepresentation .= ($line !== '' ? "    " . $line : '') . "\n";
 		}
 		$RSTRepresentation .= "\n";
 
@@ -319,6 +321,9 @@ $sampleConfigDocOutput .= "\n.. ALL_OTHER_SECTIONS_END";
 
 // retain everything after the ALL_OTHERS_SECTION_END
 $sampleConfigDocOutput .= $tmp[1];
+
+// strip trailing whitespace from all lines
+$sampleConfigDocOutput = implode("\n", array_map('rtrim', explode("\n", $sampleConfigDocOutput)));
 
 // save the updated sample config RST document
 file_put_contents($OUTPUT_FILE, $sampleConfigDocOutput);


### PR DESCRIPTION
## Summary

- Tabs from PHP source code were passing through to RST code blocks, causing `horizontal-tab` lint errors
- Empty lines inside code blocks were getting a 4-space indent prefix, creating trailing whitespace
- Added final `rtrim` pass over all output lines to catch any remaining trailing whitespace from other sources

Fixes lint errors in `admin_manual/configuration_server/config_sample_php_parameters.rst` reported in https://github.com/nextcloud/documentation/actions/runs/25723030818/job/75528674772

## Test plan

- [ ] Verify `php -f convert.php tests/test.php tests/test.rst` produces no git diff
- [x] Run against real `config.sample.php` and confirm no `horizontal-tab` or `trailing-whitespace` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)